### PR TITLE
ufsi: Invert scale to bring calculation in line with description

### DIFF
--- a/scripts/ufsi.py
+++ b/scripts/ufsi.py
@@ -87,12 +87,12 @@ def main():
         usable = zone.nr_usable_pages(order) * SZ_PAGE
         total = zone.nr_free_pages() * SZ_PAGE
         print("%s: %f (total %s, usable %s)" % (zone.name,
-            usable / total, hrsf(total), hrsf(usable)))
+            (total - usable) / total, hrsf(total), hrsf(usable)))
 
     usable = sum([z.nr_usable_pages(order) for z in zones]) * SZ_PAGE
     total = sum([z.nr_free_pages() for z in zones]) * SZ_PAGE
     print("Total: %f (total %s, usable %s)" % (
-        usable / total, hrsf(total), hrsf(usable)))
+        (total - usable) / total, hrsf(total), hrsf(usable)))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Change the calculation of the unusable free space index in `ufsi.py` to match the description and the formula from the paper. This effectively inverts the scale.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
