### PR TITLE
ufsi: Fix division by zero on out of memory machines

### DIFF
--- a/scripts/ufsi.py
+++ b/scripts/ufsi.py
@@ -86,13 +86,15 @@ def main():
     for zone in zones:
         usable = zone.nr_usable_pages(order) * SZ_PAGE
         total = zone.nr_free_pages() * SZ_PAGE
+        ufsi = (total - usable) / total if total > 0 else 1.0
         print("%s: %f (total %s, usable %s)" % (zone.name,
-            (total - usable) / total, hrsf(total), hrsf(usable)))
+            ufsi, hrsf(total), hrsf(usable)))
 
     usable = sum([z.nr_usable_pages(order) for z in zones]) * SZ_PAGE
     total = sum([z.nr_free_pages() for z in zones]) * SZ_PAGE
+    ufsi = (total - usable) / total if total > 0 else 1.0
     print("Total: %f (total %s, usable %s)" % (
-        (total - usable) / total, hrsf(total), hrsf(usable)))
+        ufsi, hrsf(total), hrsf(usable)))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Avoid trying to divide by zero on a machine without any free pages. Report the maximum UFSI of 1.0 instead.

*Testing:*

```
$ cat /proc/buddyinfo
Node 0, zone      DMA      8      4      5      5      3      2      2      1      3      2      0 
Node 0, zone    DMA32  14400   2956      0      0      1      1      0      1      0      0      0 
Node 0, zone   Normal      0      0      0      0      0      0      0      0      0      0      0 
$ ./ufsi.py 3
Node 0, zone DMA: 0.016100 (total 8.73 MiB, usable 8.59 MiB)
Node 0, zone DMA32: 0.994938 (total 160.52 MiB, usable 832.00 KiB)
Node 0, zone Normal: 1.000000 (total 0 B, usable 0 B)
Total: 0.944424 (total 169.25 MiB, usable 9.41 MiB)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
